### PR TITLE
Fix cart icon access and xml schema issues

### DIFF
--- a/app/src/main/java/com/playerlagbe/CartActivity.java
+++ b/app/src/main/java/com/playerlagbe/CartActivity.java
@@ -1,6 +1,8 @@
 package com.playerlagbe;
 
 import android.os.Bundle;
+import android.view.View;
+import android.widget.ImageView;
 import androidx.appcompat.app.AppCompatActivity;
 
 public class CartActivity extends AppCompatActivity {
@@ -9,5 +11,17 @@ public class CartActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_cart);
+
+        // Set up cart icon (disabled since we're already in cart)
+        View topBarContainer = findViewById(R.id.topAppBar);
+        if (topBarContainer != null) {
+            ImageView cartIcon = topBarContainer.findViewById(R.id.cartIcon);
+            if (cartIcon != null) {
+                // Disable cart icon since we're already in the cart
+                cartIcon.setClickable(false);
+                cartIcon.setFocusable(false);
+                cartIcon.setAlpha(0.5f); // Make it appear disabled
+            }
+        }
     }
 }

--- a/app/src/main/java/com/playerlagbe/ManagerActivity.java
+++ b/app/src/main/java/com/playerlagbe/ManagerActivity.java
@@ -1,6 +1,9 @@
 package com.playerlagbe;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.ImageView;
 import androidx.appcompat.app.AppCompatActivity;
 
 public class ManagerActivity extends AppCompatActivity {
@@ -9,5 +12,17 @@ public class ManagerActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_manager);
+
+        // Set up cart icon click listener
+        View topBarContainer = findViewById(R.id.topAppBar);
+        if (topBarContainer != null) {
+            ImageView cartIcon = topBarContainer.findViewById(R.id.cartIcon);
+            if (cartIcon != null) {
+                cartIcon.setOnClickListener(v -> {
+                    Intent intent = new Intent(ManagerActivity.this, CartActivity.class);
+                    startActivity(intent);
+                });
+            }
+        }
     }
 }

--- a/app/src/main/java/com/playerlagbe/ProfileActivity.java
+++ b/app/src/main/java/com/playerlagbe/ProfileActivity.java
@@ -1,6 +1,9 @@
 package com.playerlagbe;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.ImageView;
 import androidx.appcompat.app.AppCompatActivity;
 
 public class ProfileActivity extends AppCompatActivity {
@@ -9,5 +12,17 @@ public class ProfileActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_profile);
+
+        // Set up cart icon click listener
+        View topBarContainer = findViewById(R.id.topAppBar);
+        if (topBarContainer != null) {
+            ImageView cartIcon = topBarContainer.findViewById(R.id.cartIcon);
+            if (cartIcon != null) {
+                cartIcon.setOnClickListener(v -> {
+                    Intent intent = new Intent(ProfileActivity.this, CartActivity.class);
+                    startActivity(intent);
+                });
+            }
+        }
     }
 }

--- a/app/src/main/java/com/playerlagbe/ShopActivity.java
+++ b/app/src/main/java/com/playerlagbe/ShopActivity.java
@@ -2,6 +2,7 @@ package com.playerlagbe;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.ImageView;
 import androidx.appcompat.app.AppCompatActivity;
 
@@ -13,10 +14,16 @@ public class ShopActivity extends AppCompatActivity {
         setContentView(R.layout.activity_shop);
 
         // Set up cart icon click listener
-        ImageView cartIcon = findViewById(R.id.cartIcon);
-        cartIcon.setOnClickListener(v -> {
-            Intent intent = new Intent(ShopActivity.this, CartActivity.class);
-            startActivity(intent);
-        });
+        // Find the top bar container first, then find the cart icon within it
+        View topBarContainer = findViewById(R.id.topAppBar);
+        if (topBarContainer != null) {
+            ImageView cartIcon = topBarContainer.findViewById(R.id.cartIcon);
+            if (cartIcon != null) {
+                cartIcon.setOnClickListener(v -> {
+                    Intent intent = new Intent(ShopActivity.this, CartActivity.class);
+                    startActivity(intent);
+                });
+            }
+        }
     }
 }

--- a/app/src/main/java/com/playerlagbe/TeamsActivity.java
+++ b/app/src/main/java/com/playerlagbe/TeamsActivity.java
@@ -1,6 +1,9 @@
 package com.playerlagbe;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.view.View;
+import android.widget.ImageView;
 import androidx.appcompat.app.AppCompatActivity;
 
 public class TeamsActivity extends AppCompatActivity {
@@ -9,5 +12,17 @@ public class TeamsActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_teams);
+
+        // Set up cart icon click listener
+        View topBarContainer = findViewById(R.id.topAppBar);
+        if (topBarContainer != null) {
+            ImageView cartIcon = topBarContainer.findViewById(R.id.cartIcon);
+            if (cartIcon != null) {
+                cartIcon.setOnClickListener(v -> {
+                    Intent intent = new Intent(TeamsActivity.this, CartActivity.class);
+                    startActivity(intent);
+                });
+            }
+        }
     }
 }

--- a/app/src/main/res/layout/fragments/top_bar.xml
+++ b/app/src/main/res/layout/fragments/top_bar.xml
@@ -20,6 +20,18 @@
         style="@style/AppTitleTextStyle"
         android:gravity="start|center_vertical" />
 
+    <!-- Cart Icon -->
+    <ImageView
+        android:id="@+id/cartIcon"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:src="@drawable/ic_cart"
+        android:contentDescription="Cart"
+        android:background="?android:attr/selectableItemBackgroundBorderless"
+        android:clickable="true"
+        android:focusable="true"
+        android:layout_marginEnd="8dp" />
+
     <!-- Hamburger Menu Icon -->
     <ImageView
         android:id="@+id/hamburgerMenuIcon"

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -35,6 +35,9 @@
     <!-- Status Bar -->
     <color name="status_bar">#FAFAFA</color>
 
+    <!-- Bottom Navigation Colors -->
+    <color name="bottom_nav_item_color">#C62828</color>
+
     <!-- Material Colors -->
     <color name="colorPrimary">#C62828</color>
     <color name="colorPrimaryVariant">#B71C1C</color>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix cart icon access from included layout, add click functionality, and resolve XML schema warnings.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `cartIcon` was not directly accessible in `ShopActivity.java` because IDs within an `<include>` tag are not automatically exposed to the parent activity's root view hierarchy. This PR resolves it by first finding the included layout by its ID (`topAppBar`), then locating `cartIcon` within that view. It also addresses an XML schema warning by defining a missing color resource (`bottom_nav_item_color`) and applies the cart functionality consistently across relevant activities.

---
<a href="https://cursor.com/background-agent?bcId=bc-deef3c72-e186-4d42-ba05-8c55bcc8a997">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-deef3c72-e186-4d42-ba05-8c55bcc8a997">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>